### PR TITLE
Fix neural agent observation parsing

### DIFF
--- a/multi_evo_sim/agents/neural_agent.py
+++ b/multi_evo_sim/agents/neural_agent.py
@@ -14,8 +14,30 @@ class NeuralAgent(BaseAgent):
         self.network = network
 
     def act(self, observation):
-        """Convierte la salida de la red en una acción básica."""
-        obs_vector = np.array(list(observation.values()), dtype=float)
+        """Convierte la observación en un vector numérico y decide la acción."""
+        # Algunas entradas de la observación contienen secuencias (por ejemplo
+        # la posición o la lista de recursos). Convertir ese diccionario en un
+        # array directamente provoca un ``ValueError``. Extraemos únicamente
+        # valores numéricos para alimentar a la red neuronal.
+        position = observation.get("position", (0, 0))
+        resource_here = observation.get("resource_here", 0)
+        inventory = observation.get("inventory", 0)
+        danger = 1 if observation.get("danger", False) else 0
+        num_resources = len(observation.get("resources", []))
+
+        features = np.array(
+            [position[0], position[1], resource_here, inventory, num_resources, danger],
+            dtype=float,
+        )
+
+        # Ajustamos el vector al tamaño que espera la red neuronal
+        if self.network.input_size < features.size:
+            obs_vector = features[: self.network.input_size]
+        elif self.network.input_size > features.size:
+            obs_vector = np.pad(features, (0, self.network.input_size - features.size))
+        else:
+            obs_vector = features
+
         output = self.network.forward(obs_vector)
         action_idx = int(np.argmax(output))
 


### PR DESCRIPTION
## Summary
- parse environment observation into numeric vector
- pad/trim feature vector to network input size

## Testing
- `python3 - <<'PY'
from multi_evo_sim.env.world import World
from multi_evo_sim.env.resource import Resource
from multi_evo_sim.agents.neural_agent import NeuralAgent

world = World(width=10, height=10, resources=[Resource((0,0))])
agent = NeuralAgent(input_size=2)
world.add_agent(agent, position=(0, 0))
world.step()
print('Inventory:', agent.inventory)
PY`

------
https://chatgpt.com/codex/tasks/task_e_683f73fafe908331be536c0402e27569