### PR TITLE
Add simple visualization and experiment logging

### DIFF
--- a/multi_evo_sim/main.py
+++ b/multi_evo_sim/main.py
@@ -5,7 +5,8 @@ from .agents.base_agent import BaseAgent
 from .config import POPULATION_SIZE
 from .evolution.genetic_algorithm import GeneticAlgorithm
 from .evolution.fitness_functions import fitness_combinado
-from .visualization.logger import log
+from .visualization.logger import ExperimentLogger, log
+from .visualization.render import Renderer
 import random
 
 
@@ -22,6 +23,9 @@ def run_simulation():
     agent = NeuralAgent(input_size=2)
     world.add_agent(agent, position=(0, 0))
 
+    renderer = Renderer()
+    exp_logger = ExperimentLogger()
+
     # O alternativamente: población evolutiva
     population = [random_agent() for _ in range(POPULATION_SIZE)]
     for ag in population:
@@ -29,13 +33,20 @@ def run_simulation():
 
     ga = GeneticAlgorithm(population, fitness_combinado)
     fitness = ga.step()
+    fronts, _ = ga.fast_non_dominated_sort(fitness)
+    exp_logger.log_fitness(0, fitness)
+    if fronts:
+        exp_logger.log_pareto_front(0, fronts[0], fitness)
     log(f"Fitness calculado: {fitness}")
 
     # Ejecutar un paso en el mundo para que los agentes actúen
-    world.step()
+    for step in range(3):
+        world.step()
+        renderer.draw(world)
     for ag in population:
         log(f"Inventario del agente: {ag.inventory}")
     log(f"Inventario del agente individual (Neural): {agent.inventory}")
+    exp_logger.save()
 
 
 if __name__ == "__main__":

--- a/multi_evo_sim/visualization/logger.py
+++ b/multi_evo_sim/visualization/logger.py
@@ -1,4 +1,7 @@
 import logging
+from typing import Iterable, List
+
+import pandas as pd
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
@@ -6,3 +9,38 @@ logging.basicConfig(level=logging.INFO)
 
 def log(message):
     logger.info(message)
+
+
+class ExperimentLogger:
+    """Registra estadísticas de fitness y frentes de Pareto en archivos CSV."""
+
+    def __init__(self, fitness_file: str = "fitness_log.csv", pareto_file: str = "pareto_front.csv"):
+        self.fitness_file = fitness_file
+        self.pareto_file = pareto_file
+        self._fitness_rows: List[dict] = []
+        self._pareto_rows: List[dict] = []
+
+    def log_fitness(self, iteration: int, fitness_values: Iterable):
+        for idx, fit in enumerate(fitness_values):
+            if not isinstance(fit, (list, tuple)):
+                fit = [fit]
+            row = {"iteration": iteration, "individual": idx}
+            for j, val in enumerate(fit):
+                row[f"obj_{j}"] = val
+            self._fitness_rows.append(row)
+
+    def log_pareto_front(self, iteration: int, front_indices: Iterable[int], fitness_values: Iterable):
+        for idx in front_indices:
+            fit = fitness_values[idx]
+            if not isinstance(fit, (list, tuple)):
+                fit = [fit]
+            row = {"iteration": iteration, "individual": idx}
+            for j, val in enumerate(fit):
+                row[f"obj_{j}"] = val
+            self._pareto_rows.append(row)
+
+    def save(self):
+        if self._fitness_rows:
+            pd.DataFrame(self._fitness_rows).to_csv(self.fitness_file, index=False)
+        if self._pareto_rows:
+            pd.DataFrame(self._pareto_rows).to_csv(self.pareto_file, index=False)

--- a/multi_evo_sim/visualization/render.py
+++ b/multi_evo_sim/visualization/render.py
@@ -1,9 +1,38 @@
+import matplotlib.pyplot as plt
+
+
 class Renderer:
     """Renderiza el mundo y los agentes utilizando matplotlib."""
 
     def __init__(self):
-        pass
+        plt.ion()
+        self.fig, self.ax = plt.subplots()
 
     def draw(self, world):
-        """Dibuja el mundo. Placeholder."""
-        pass
+        """Dibuja el estado actual del mundo."""
+        self.ax.clear()
+        self.ax.set_xlim(0, world.width)
+        self.ax.set_ylim(0, world.height)
+        if world.grid:
+            self.ax.set_xticks(range(world.width + 1))
+            self.ax.set_yticks(range(world.height + 1))
+            self.ax.grid(True, which="both")
+
+        for res in world.resources:
+            if not res.consumed:
+                x, y = res.position
+                if world.grid:
+                    x += 0.5
+                    y += 0.5
+                self.ax.scatter(x, y, c="green", s=100, marker="s")
+
+        for _, pos in world.agents:
+            x, y = pos
+            if world.grid:
+                x += 0.5
+                y += 0.5
+            self.ax.scatter(x, y, c="red", s=100, marker="o")
+
+        self.ax.set_title("Simulación")
+        plt.draw()
+        plt.pause(0.001)


### PR DESCRIPTION
## Summary
- implement a matplotlib renderer to display the world
- add `ExperimentLogger` that stores fitness values and Pareto fronts in CSV
- record data and render steps from `main.py`

## Testing
- `pytest -q`
- `python -m multi_evo_sim.main`

------
https://chatgpt.com/codex/tasks/task_e_683f792aa3288331a2cdf378e551515f