### PR TITLE
Add color support for agents

### DIFF
--- a/multi_evo_sim/agents/base_agent.py
+++ b/multi_evo_sim/agents/base_agent.py
@@ -11,8 +11,9 @@ class ActionType(Enum):
 class BaseAgent:
     """Agente base del sistema evolutivo."""
 
-    def __init__(self, genotype=None):
+    def __init__(self, genotype=None, color="red"):
         self.genotype = genotype or []
+        self.color = color
         # Cantidad de recursos recolectados por el agente
         self.inventory = 0
 

--- a/multi_evo_sim/agents/neural_agent.py
+++ b/multi_evo_sim/agents/neural_agent.py
@@ -10,7 +10,7 @@ class NeuralAgent(BaseAgent):
     def __init__(self, input_size, hidden_size=4, output_size=6, genotype=None):
         # Si se proporciona un genotipo, inicializa la red a partir de él
         network = SimpleNeuralNetwork(input_size, hidden_size, output_size, genotype)
-        super().__init__(network.genotype.tolist())
+        super().__init__(network.genotype.tolist(), color="blue")
         self.network = network
 
     def act(self, observation):

--- a/multi_evo_sim/visualization/render.py
+++ b/multi_evo_sim/visualization/render.py
@@ -26,12 +26,13 @@ class Renderer:
                     y += 0.5
                 self.ax.scatter(x, y, c="green", s=100, marker="s")
 
-        for _, pos in world.agents:
+        for agent, pos in world.agents:
             x, y = pos
             if world.grid:
                 x += 0.5
                 y += 0.5
-            self.ax.scatter(x, y, c="red", s=100, marker="o")
+            color = getattr(agent, "color", "red")
+            self.ax.scatter(x, y, c=color, s=100, marker="o")
 
         self.ax.set_title("Simulación")
         plt.draw()


### PR DESCRIPTION
## Summary
- add `color` attribute to `BaseAgent`
- set `NeuralAgent` color to blue
- render agents in their designated colors

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fec39d8208331be9dc2602a32800f