### PR TITLE
Add automatic feature sizing to NeuralAgent

### DIFF
--- a/multi_evo_sim/agents/neural_agent.py
+++ b/multi_evo_sim/agents/neural_agent.py
@@ -7,28 +7,46 @@ from .simple_network import SimpleNeuralNetwork
 class NeuralAgent(BaseAgent):
     """Agente que utiliza una red neuronal simple como política."""
 
-    def __init__(self, input_size, hidden_size=4, output_size=6, genotype=None):
-        # Si se proporciona un genotipo, inicializa la red a partir de él
+    def __init__(self, input_size=None, hidden_size=4, output_size=6, genotype=None):
+        """Crea un ``NeuralAgent`` con una red neuronal mínima.
+
+        Si ``input_size`` es ``None`` se calcula automáticamente a partir del
+        número de características que genera :meth:`_extract_features`.
+        """
+        if input_size is None:
+            input_size = self.feature_size()
+
         network = SimpleNeuralNetwork(input_size, hidden_size, output_size, genotype)
         super().__init__(network.genotype.tolist(), color="blue")
         self.network = network
 
-    def act(self, observation):
-        """Convierte la observación en un vector numérico y decide la acción."""
-        # Algunas entradas de la observación contienen secuencias (por ejemplo
-        # la posición o la lista de recursos). Convertir ese diccionario en un
-        # array directamente provoca un ``ValueError``. Extraemos únicamente
-        # valores numéricos para alimentar a la red neuronal.
+    @staticmethod
+    def _extract_features(observation):
+        """Devuelve un ``numpy.ndarray`` con las características numéricas de la observación."""
         position = observation.get("position", (0, 0))
         resource_here = observation.get("resource_here", 0)
         inventory = observation.get("inventory", 0)
         danger = 1 if observation.get("danger", False) else 0
         num_resources = len(observation.get("resources", []))
 
-        features = np.array(
+        return np.array(
             [position[0], position[1], resource_here, inventory, num_resources, danger],
             dtype=float,
         )
+
+    @classmethod
+    def feature_size(cls):
+        """Número de valores que produce :meth:`_extract_features`."""
+        return cls._extract_features({}).size
+
+    def act(self, observation):
+        """Convierte la observación en un vector numérico y decide la acción."""
+        # Algunas entradas de la observación contienen secuencias (por ejemplo
+        # la posición o la lista de recursos). Convertir ese diccionario en un
+        # array directamente provoca un ``ValueError``. Por ello se utiliza la
+        # función auxiliar ``_extract_features`` que devuelve únicamente valores
+        # numéricos.
+        features = self._extract_features(observation)
 
         # Ajustamos el vector al tamaño que espera la red neuronal
         if self.network.input_size < features.size:

--- a/multi_evo_sim/main.py
+++ b/multi_evo_sim/main.py
@@ -24,7 +24,7 @@ def run_simulation():
     renderer.draw(world)
 
     # Agente individual para prueba rápida (NeuralAgent)
-    agent = NeuralAgent(input_size=2)
+    agent = NeuralAgent()
     world.add_agent(agent, position=(0, 0))
     renderer.draw(world)
 

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -17,7 +17,7 @@ def test_base_agent_act():
 
 
 def test_neural_agent_act_returns_action():
-    agent = NeuralAgent(input_size=2)
+    agent = NeuralAgent()
     obs = {
         'position': (1, 1),
         'resource_here': 0,


### PR DESCRIPTION
## Summary
- make `NeuralAgent` compute its input size automatically
- refactor feature extraction into `_extract_features`
- update tests and example usage to use the inferred size

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683ff87600948331a34832eb459cb1d1