### PR TITLE
Add nearest resource features and logging for gather action

### DIFF
--- a/multi_evo_sim/agents/base_agent.py
+++ b/multi_evo_sim/agents/base_agent.py
@@ -1,5 +1,8 @@
 from enum import Enum
+import logging
 import random
+
+logger = logging.getLogger(__name__)
 
 
 class ActionType(Enum):
@@ -33,6 +36,7 @@ class BaseAgent:
         moverá en una dirección aleatoria.
         """
         if observation.get("resource_here"):
+            logger.info("GATHER action triggered at %s", observation.get("position"))
             return Action(ActionType.GATHER)
 
         dx, dy = random.choice([(1, 0), (-1, 0), (0, 1), (0, -1)])

--- a/multi_evo_sim/agents/neural_agent.py
+++ b/multi_evo_sim/agents/neural_agent.py
@@ -33,13 +33,34 @@ class NeuralAgent(BaseAgent):
     def _extract_features(observation):
         """Devuelve un ``numpy.ndarray`` con las características numéricas de la observación."""
         position = observation.get("position", (0, 0))
-        resource_here = observation.get("resource_here", 0)
+        resources = observation.get("resources", [])
+        resource_here = int(bool(observation.get("resource_here", 0)))
         inventory = observation.get("inventory", 0)
         danger = 1 if observation.get("danger", False) else 0
-        num_resources = len(observation.get("resources", []))
+        num_resources = len(resources)
+
+        if resources:
+            nearest = min(
+                resources,
+                key=lambda r: (r[0] - position[0]) ** 2 + (r[1] - position[1]) ** 2,
+            )
+            dx = nearest[0] - position[0]
+            dy = nearest[1] - position[1]
+        else:
+            dx = 0
+            dy = 0
 
         return np.array(
-            [position[0], position[1], resource_here, inventory, num_resources, danger],
+            [
+                position[0],
+                position[1],
+                dx,
+                dy,
+                resource_here,
+                inventory,
+                num_resources,
+                danger,
+            ],
             dtype=float,
         )
 


### PR DESCRIPTION
## Summary
- log when base agent performs a GATHER action
- include dx and dy to the nearest resource in neural agent features

## Testing
- `pytest -q`
- `python - <<'PY'
from multi_evo_sim.training import train
train(population_size=4, generations=2)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68400e65529483318c78483ead8234db