### PR TITLE
Add persistence test for MemeticNSGAII elitism

### DIFF
--- a/tests/test_memetic_algorithm.py
+++ b/tests/test_memetic_algorithm.py
@@ -23,3 +23,16 @@ def test_memetic_elitism_keeps_best_individual():
     best = max(population, key=lambda ag: ag.genotype[0] + ag.genotype[1]).genotype[:]
     ga.step()
     assert any(ind.genotype == best for ind in ga.population)
+
+
+def test_memetic_elitism_persists_over_generations():
+    import random
+
+    random.seed(0)
+    population = [BaseAgent(genotype=[i, i]) for i in range(4)]
+    fitness = lambda ag: [ag.genotype[0] + ag.genotype[1]]
+    ga = MemeticNSGAII(population, fitness, mutation_rate=0.0, local_search_iters=0)
+    best = max(population, key=lambda ag: ag.genotype[0] + ag.genotype[1]).genotype[:]
+    for _ in range(5):
+        ga.step()
+    assert any(ind.genotype == best for ind in ga.population)


### PR DESCRIPTION
## Summary
- add a new test that runs `MemeticNSGAII.step()` several times
- verify the best initial genotype remains in the population

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840443e1fd883319bd9b2c9406c1155