### PR TITLE
Enable optional memetic algorithm

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,10 @@ multi_evo_sim/
    python -m multi_evo_sim.training
    ```
 
+   Si deseas utilizar el algoritmo memético `MemeticNSGAII`, ejecuta el módulo
+   con la opción `--memetic` o establece `USE_MEMETIC_ALGORITHM = True` en
+   `multi_evo_sim/config.py`.
+
    Durante el entrenamiento se guardan tres archivos CSV: `fitness_log.csv`,
    `pareto_front.csv` e `inventory_log.csv`, donde este último almacena el
    inventario final de cada agente en cada generación.

--- a/multi_evo_sim/config.py
+++ b/multi_evo_sim/config.py
@@ -2,6 +2,11 @@ WORLD_WIDTH = 10
 WORLD_HEIGHT = 10
 POPULATION_SIZE = 10
 
+# Algoritmo evolutivo por defecto. Si se establece en ``True`` se empleará
+# ``MemeticNSGAII`` en ``training.py``. De lo contrario se usará
+# ``GeneticAlgorithm``.
+USE_MEMETIC_ALGORITHM = False
+
 # Pesos para las distintas métricas de fitness
 FITNESS_WEIGHTS = {
     # Las métricas que tienden a permanecer constantes en simulaciones

--- a/multi_evo_sim/training.py
+++ b/multi_evo_sim/training.py
@@ -5,10 +5,12 @@ from .env.resource import Resource
 from .agents.base_agent import BaseAgent
 from .agents.neural_agent import NeuralAgent
 from .evolution.genetic_algorithm import GeneticAlgorithm
-from .evolution.memetic_algorithm import MemeeticAlgorithm
+from .evolution.memetic_algorithm import MemeticNSGAII
 from .evolution.fitness_functions import fitness_combinado
 from .visualization.logger import ExperimentLogger, log
 from .visualization.render import Renderer
+from . import config
+import argparse
 
 
 renderer = Renderer()
@@ -35,10 +37,11 @@ def _evaluate_agent(agent, steps: int = 100, draw: bool=False) -> list:
     return fitness_combinado(agent)
 
 
-def train(population_size=10, generations=1000):
-    """Lanza un proceso evolutivo sencillo con NSGA-II."""
+def train(population_size=10, generations=1000, memetic: bool = config.USE_MEMETIC_ALGORITHM):
+    """Lanza un proceso evolutivo con NSGA-II o MemeticNSGAII."""
     population = [NeuralAgent() for _ in range(population_size)]
-    ga = MemeeticAlgorithm(population, _evaluate_agent)
+    ga_cls = MemeticNSGAII if memetic else GeneticAlgorithm
+    ga = ga_cls(population, _evaluate_agent)
     logger = ExperimentLogger()
 
     for gen in range(1, generations+1):
@@ -59,4 +62,11 @@ def train(population_size=10, generations=1000):
 
 
 if __name__ == "__main__":
-    train()
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--memetic",
+        action="store_true",
+        help="Usar MemeticNSGAII en lugar de GeneticAlgorithm",
+    )
+    args = parser.parse_args()
+    train(memetic=args.memetic or config.USE_MEMETIC_ALGORITHM)


### PR DESCRIPTION
## Summary
- add `USE_MEMETIC_ALGORITHM` flag in configuration
- allow `training.py` to switch between `GeneticAlgorithm` and `MemeticNSGAII`
- document how to enable the memetic algorithm for training

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840443e30588331b8b84a8cd0e39a5a