### PR TITLE
Handle single-gene crossover

### DIFF
--- a/multi_evo_sim/evolution/genetic_algorithm.py
+++ b/multi_evo_sim/evolution/genetic_algorithm.py
@@ -81,9 +81,9 @@ class NSGAII:
 
     # --- Operadores genéticos ---
     def crossover(self, parent1, parent2):
-        if random.random() > self.crossover_rate:
-            return copy.deepcopy(parent1), copy.deepcopy(parent2)
         g1, g2 = parent1.genotype, parent2.genotype
+        if len(g1) < 2 or random.random() > self.crossover_rate:
+            return copy.deepcopy(parent1), copy.deepcopy(parent2)
         point = random.randint(1, len(g1) - 1)
         child1_genotype = g1[:point] + g2[point:]
         child2_genotype = g2[:point] + g1[point:]

--- a/tests/test_evolution.py
+++ b/tests/test_evolution.py
@@ -18,3 +18,10 @@ def test_nsga_step_population_size_constant():
     ga = NSGAII(population, lambda ag: [len(ag.genotype)])
     ga.step()
     assert len(ga.population) == 4
+
+
+def test_nsga_step_single_gene_individuals():
+    population = [BaseAgent(genotype=[i]) for i in range(4)]
+    ga = NSGAII(population, lambda ag: [len(ag.genotype)])
+    ga.step()
+    assert len(ga.population) == 4


### PR DESCRIPTION
## Summary
- avoid crossover when genotype length is less than two
- test that a single-gene population can evolve without errors

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840443eaf448331bc6a54f09bc149d5