### PR TITLE
Add danger zones to world

### DIFF
--- a/multi_evo_sim/env/world.py
+++ b/multi_evo_sim/env/world.py
@@ -55,6 +55,17 @@ class World:
         pos = self._random_position()
         self.resources.append(Resource(pos, value))
 
+    def spawn_danger_zone(self):
+        """Genera una zona peligrosa en una posición libre."""
+        pos = self._random_position()
+        if self.grid:
+            self.danger_zones.append(pos)
+        else:
+            x, y = pos
+            x = min(x, self.width - 1)
+            y = min(y, self.height - 1)
+            self.danger_zones.append((x, y, x + 1, y + 1))
+
     # ------------------------------------------------------------------
     # Utilidades internas
     # ------------------------------------------------------------------
@@ -64,7 +75,7 @@ class World:
             x = random.uniform(0, self.width) if not self.grid else random.randrange(self.width)
             y = random.uniform(0, self.height) if not self.grid else random.randrange(self.height)
             pos = (x, y)
-            if not self.is_obstacle(pos):
+            if not self.is_obstacle(pos) and not self.is_danger(pos):
                 return pos
 
     def is_obstacle(self, position):

--- a/multi_evo_sim/training.py
+++ b/multi_evo_sim/training.py
@@ -39,6 +39,8 @@ def _evaluate_agent(agent, steps: int = 100, draw: bool=False) -> list:
     # crecimiento durante la evaluacion, generando fitness mas variado.
     resources = [Resource((random.randint(0, 9), random.randint(0, 9))) for _ in range(10)]
     world = World(width=10, height=10, resources=resources)
+    for _ in range(3):
+        world.spawn_danger_zone()
     world.add_agent(agent, position=(random.randint(0, 9), random.randint(0, 9)))
     # Agregar un compañero basico para posibilitar acciones de cooperacion
     world.add_agent(BaseAgent(), position=(random.randint(0, 9), random.randint(0, 9)))

--- a/multi_evo_sim/visualization/render.py
+++ b/multi_evo_sim/visualization/render.py
@@ -1,4 +1,5 @@
 import matplotlib.pyplot as plt
+from matplotlib.patches import Rectangle
 
 
 class Renderer:
@@ -17,6 +18,15 @@ class Renderer:
             self.ax.set_xticks(range(world.width + 1))
             self.ax.set_yticks(range(world.height + 1))
             self.ax.grid(True, which="both")
+
+        for zone in world.danger_zones:
+            if world.grid:
+                x, y = zone
+                rect = Rectangle((x, y), 1, 1, color="red", alpha=0.3)
+            else:
+                x1, y1, x2, y2 = zone
+                rect = Rectangle((x1, y1), x2 - x1, y2 - y1, color="red", alpha=0.3)
+            self.ax.add_patch(rect)
 
         for res in world.resources:
             if not res.consumed:

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -4,7 +4,7 @@ import sys
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 from multi_evo_sim.env.world import World
 from multi_evo_sim.env.resource import Resource
-from multi_evo_sim.agents.base_agent import BaseAgent
+from multi_evo_sim.agents.base_agent import BaseAgent, Action, ActionType
 
 
 def test_world_step_gather():
@@ -15,3 +15,24 @@ def test_world_step_gather():
     assert agent.inventory == 1
     assert world.resources[0].consumed is True
     assert world.agents[0][1] == (0, 0)
+
+
+class FixedMoveAgent(BaseAgent):
+    """Agente de prueba que siempre se mueve en una dirección fija."""
+
+    def __init__(self, direction):
+        super().__init__()
+        self.direction = direction
+
+    def act(self, observation):
+        return Action(ActionType.MOVE, direction=self.direction)
+
+
+def test_danger_zone_kills_agent():
+    world = World(width=2, height=2, danger_zones=[(1, 0)], resource_regen=False)
+    agent = FixedMoveAgent((1, 0))
+    world.add_agent(agent, position=(0, 0))
+    assert world.is_danger((1, 0)) is True
+    world.step()
+    assert agent.alive is False
+    assert world.agents[0][1] == (1, 0)


### PR DESCRIPTION
## Summary
- implement `World.spawn_danger_zone` and avoid overlapping when choosing positions
- populate danger zones during agent evaluation
- draw danger zones in `Renderer`
- test that danger zones kill agents

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842b97584508331abe61f1c32eadc58