### PR TITLE
Muestra indice de individuo en renderizado

### DIFF
--- a/multi_evo_sim/training.py
+++ b/multi_evo_sim/training.py
@@ -35,8 +35,13 @@ def _evaluate_agent(
     steps: int = 100,
     draw: bool = False,
     generation: int | None = None,
+    agent_index: int | None = None,
 ) -> list:
-    """Ejecuta una simulaci\u00f3n corta con compa\u00f1eros y devuelve el fitness."""
+    """Ejecuta una simulaci\u00f3n corta con compa\u00f1eros y devuelve el fitness.
+
+    Cuando ``draw`` es ``True`` se pasa ``agent_index`` a ``Renderer.draw`` para
+    mostrar qué individuo se evalúa.
+    """
     agent.inventory = 0
     agent.resources_collected = 0
     agent.shared_resources = 0
@@ -53,7 +58,7 @@ def _evaluate_agent(
     for _ in range(steps):
         world.step()
         if draw:
-            _get_renderer().draw(world, generation)
+            _get_renderer().draw(world, generation, agent_index)
     return fitness_combinado(agent)
 
 
@@ -66,8 +71,14 @@ def _evaluate_population(
 ):
     if n_jobs <= 1:
         return [
-            _evaluate_agent(ind, steps=steps, draw=draw, generation=generation)
-            for ind in population
+            _evaluate_agent(
+                ind,
+                steps=steps,
+                draw=draw,
+                generation=generation,
+                agent_index=i if draw else None,
+            )
+            for i, ind in enumerate(population)
         ]
     pool = get_pool(n_jobs)
     func = partial(_evaluate_agent, steps=steps, draw=draw)

--- a/multi_evo_sim/visualization/render.py
+++ b/multi_evo_sim/visualization/render.py
@@ -25,10 +25,16 @@ class Renderer:
                 self.record = False
 
 
-    def draw(self, world, generation: int | None = None):
+    def draw(
+        self,
+        world,
+        generation: int | None = None,
+        agent_index: int | None = None,
+    ):
         """Dibuja el estado actual del mundo.
 
-        Si se proporciona ``generation`` muestra el n\u00famero en el t\u00edtulo.
+        Si se proporcionan ``generation`` o ``agent_index`` se muestran en el
+        t\u00edtulo de la figura.
         """
         self.ax.clear()
         self.ax.set_xlim(0, world.width)
@@ -60,10 +66,12 @@ class Renderer:
                 x += 0.5
                 y += 0.5
             self.ax.scatter(x, y, c="purple", s=150, marker="*")
+        titulo = ["Simulación"]
         if generation is not None:
-            self.ax.set_title(f"Simulación - generación {generation}")
-        else:
-            self.ax.set_title("Simulación")
+            titulo.append(f"generación {generation}")
+        if agent_index is not None:
+            titulo.append(f"individuo {agent_index}")
+        self.ax.set_title(" - ".join(titulo))
 
         plt.draw()
         plt.pause(0.001)


### PR DESCRIPTION
## Summary
- agrega un parámetro opcional `agent_index` en `Renderer.draw`
- pasa el índice del individuo desde `training._evaluate_population` cuando se dibuja
- refleja el nuevo parámetro en `_evaluate_agent`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846b926bfcc8331a7d02c3648e54797